### PR TITLE
fixes handling of psp-std, scalaz and shapeless

### DIFF
--- a/foundation/src/main/scala/org/scalameta/reflection/Ensugar.scala
+++ b/foundation/src/main/scala/org/scalameta/reflection/Ensugar.scala
@@ -65,7 +65,6 @@ trait Ensugar {
                 case TypeApplicationWithInferredTypeArguments(original) => Some(original)
                 case ApplicationWithArrayInstantiation(original) => Some(original)
                 case ApplicationWithInferredImplicitArguments(original) => Some(original)
-                case ApplicationWithInsertedApply(original) => Some(original)
                 case ApplicationWithNamesOrDefaults(original) => Some(original)
                 case ApplicationWithInsertedParentheses(original) => Some(original)
                 case StandalonePartialFunction(original) => Some(original)
@@ -555,15 +554,6 @@ trait Ensugar {
           def ensugar(tree: Tree): Option[Tree] = (tree, dissectApplied(tree)) match {
             case (ApplyToImplicitArgs(fn, _), _) => Some(fn)
             case (Apply(fn, args), Applied(Select(This(_), nme.CONSTRUCTOR), _, _)) if isImplicitMethodType(fn.tpe) => Some(fn)
-            case _ => None
-          }
-        }
-
-        object ApplicationWithInsertedApply extends SingleEnsugarer {
-          // TODO: make this work, putting a workaround in place for now
-          // def ensugar(tree: Tree): Option[Tree] = tree.metadata.get("originalApplee").map(_.asInstanceOf[Tree])
-          def ensugar(tree: Tree): Option[Tree] = tree match {
-            case Select(qual, _) if tree.symbol.name == nme.apply && tree.symbol.paramss.nonEmpty && !qual.isInstanceOf[Super] => Some(qual)
             case _ => None
           }
         }

--- a/interface/src/main/scala/scala/meta/internal/hosts/scalac/Host.scala
+++ b/interface/src/main/scala/scala/meta/internal/hosts/scalac/Host.scala
@@ -623,14 +623,14 @@ class Host[G <: ScalaGlobal](val g: G) extends PalladiumHost with GlobalToolkit 
       case in @ g.CompoundTypeTree(templ) =>
         val p.Templ(early, parents, self, stats) = templ.cvt
         require(early.isEmpty && parents.forall(_.argss.isEmpty) && self.name.isEmpty && self.decltpe.isEmpty && stats.forall(_.isRefineStat))
-        p.Type.Compound(parents.map(_.tpe), stats)
+        if (stats.nonEmpty) p.Type.Compound(parents.map(_.tpe), stats) else p.Type.Compound(parents.map(_.tpe))
       case in @ g.AppliedTypeTree(tpt, args) =>
         // TODO: infer whether that was really Apply, Function or Tuple
         // TODO: precisely infer whether that was infix application or normal application
         if (g.definitions.FunctionClass.seq.contains(tpt.tpe.typeSymbolDirect)) p.Type.Function(args.init.cvt_!, args.last.cvt_!)
         else if (g.definitions.TupleClass.seq.contains(tpt.tpe.typeSymbolDirect) && args.length > 1) p.Type.Tuple(args.cvt_!)
         else in match {
-          case g.AppliedTypeTree(tpt @ g.RefTree(_, name), List(lhs, rhs)) if name.looksLikeInfix => p.Type.ApplyInfix(lhs.cvt_!, tpt.cvt_!, rhs.cvt_!)
+          case g.AppliedTypeTree(tpt @ g.Ident(name), List(lhs, rhs)) if name.looksLikeInfix => p.Type.ApplyInfix(lhs.cvt_!, tpt.cvt_!, rhs.cvt_!)
           case _ => p.Type.Apply(tpt.cvt_!, args.cvt_!)
         }
       case in @ g.ExistentialTypeTree(tpt, whereClauses) =>

--- a/interface/src/main/scala/scala/meta/internal/hosts/scalac/Host.scala
+++ b/interface/src/main/scala/scala/meta/internal/hosts/scalac/Host.scala
@@ -48,8 +48,8 @@ class Host[G <: ScalaGlobal](val g: G) extends PalladiumHost with GlobalToolkit 
         def isBackquoted: Boolean = gtree match {
           // TODO: infer isBackquoted
           // TODO: iirc according to Denys, info in BackquotedIdentifierAttachment might be incomplete
-          case gtree: g.Ident => gtree.isBackquoted || scala.meta.syntactic.parsers.keywords.contains(gtree.name.toString)
-          case gtree: g.Select => scala.meta.syntactic.parsers.keywords.contains(gtree.name.toString)
+          case gtree: g.Ident => gtree.isBackquoted || scala.meta.syntactic.parsers.keywords.contains(gtree.alias)
+          case gtree: g.NameTree => scala.meta.syntactic.parsers.keywords.contains(gtree.alias)
           case _ => false
         }
       }

--- a/interface/src/main/scala/scala/meta/internal/hosts/scalac/Host.scala
+++ b/interface/src/main/scala/scala/meta/internal/hosts/scalac/Host.scala
@@ -501,7 +501,7 @@ class Host[G <: ScalaGlobal](val g: G) extends PalladiumHost with GlobalToolkit 
             else p.Term.For(penums, body.cvt_!)
           case q"$lhs.$op($arg)" if op.looksLikeInfix && !lhs.isInstanceOf[g.Super] =>
             p.Term.ApplyInfix(lhs.cvt_!, fn.symbol.asTerm.precvt(lhs.tpe, fn), Nil, List(parg(arg)))
-          case _ if g.definitions.TupleClass.seq.contains(in.symbol.companion) =>
+          case _ if g.definitions.TupleClass.seq.contains(in.symbol.companion) && args.length > 1 =>
             p.Term.Tuple(args.cvt_!)
           case _ =>
             p.Term.Apply(fn.cvt_!, pargs(args))
@@ -595,7 +595,7 @@ class Host[G <: ScalaGlobal](val g: G) extends PalladiumHost with GlobalToolkit 
         // TODO: infer whether that was really Apply, Function or Tuple
         // TODO: precisely infer whether that was infix application or normal application
         if (g.definitions.FunctionClass.seq.contains(tpt.tpe.typeSymbolDirect)) p.Type.Function(args.init.cvt_!, args.last.cvt_!)
-        else if (g.definitions.TupleClass.seq.contains(tpt.tpe.typeSymbolDirect)) p.Type.Tuple(args.cvt_!)
+        else if (g.definitions.TupleClass.seq.contains(tpt.tpe.typeSymbolDirect) && args.length > 1) p.Type.Tuple(args.cvt_!)
         else in match {
           case g.AppliedTypeTree(tpt @ g.RefTree(_, name), List(lhs, rhs)) if name.looksLikeInfix => p.Type.ApplyInfix(lhs.cvt_!, tpt.cvt_!, rhs.cvt_!)
           case _ => p.Type.Apply(tpt.cvt_!, args.cvt_!)

--- a/plugin/src/main/scala/scala/meta/internal/hosts/scalac/typechecker/Analyzer.scala
+++ b/plugin/src/main/scala/scala/meta/internal/hosts/scalac/typechecker/Analyzer.scala
@@ -199,8 +199,13 @@ trait Analyzer extends NscAnalyzer with GlobalToolkit {
           // List extractors are mixed with :: patterns. See Test5 in lists.scala.
           //
           // TODO SI-6609 Eliminate this special case once the old pattern matcher is removed.
-          def dealias(sym: Symbol) =
-            (atPos(tree.pos.makeTransparent) {gen.mkAttributedRef(sym)} setPos tree.pos, sym.owner.thisType)
+          def dealias(sym: Symbol) = {
+            // NOTE: this is a meaningful difference from the code in Typers.scala
+            //-(atPos(tree.pos.makeTransparent) {gen.mkAttributedRef(sym)} setPos tree.pos, sym.owner.thisType)
+            val result @ Select(qual, _) = atPos(tree.pos.makeTransparent) {gen.mkAttributedRef(sym)} setPos tree.pos
+            qual.appendMetadata("original" -> site)
+            (result, sym.owner.thisType)
+          }
           sym.name match {
             case nme.List => return dealias(ListModule)
             case nme.Seq  => return dealias(SeqModule)
@@ -214,7 +219,9 @@ trait Analyzer extends NscAnalyzer with GlobalToolkit {
             case Select(qual, _) => Select(qual, nme.PACKAGEkw)
             case SelectFromTypeTree(qual, _) => Select(qual, nme.PACKAGEkw)
           }
-        }}
+        // NOTE: this is a meaningful difference from the code in Typers.scala
+        //-}}
+        }}.appendMetadata("original" -> site)
         val tree1 = atPos(tree.pos) {
           tree match {
             case Ident(name) => Select(qual, name)

--- a/plugin/src/main/scala/scala/meta/internal/hosts/scalac/typechecker/Analyzer.scala
+++ b/plugin/src/main/scala/scala/meta/internal/hosts/scalac/typechecker/Analyzer.scala
@@ -1398,7 +1398,9 @@ trait Analyzer extends NscAnalyzer with GlobalToolkit {
       }
       def typedApply(tree: Apply) = tree match {
         case Apply(Block(stats, expr), args) =>
-          typed1(atPos(tree.pos)(Block(stats, Apply(expr, args) setPos tree.pos.makeTransparent)), mode, pt)
+          // NOTE: this is a meaningful difference from the code in Typers.scala
+          //-typed1(atPos(tree.pos)(Block(stats, Apply(expr, args) setPos tree.pos.makeTransparent)), mode, pt)
+          typed1(atPos(tree.pos)(Block(stats, treeCopy.Apply(tree, expr, args) setPos tree.pos.makeTransparent)), mode, pt)
         case Apply(fun, args) =>
           normalTypedApply(tree, fun, args) match {
             // NOTE: this is a meaningful difference from the code in Typers.scala

--- a/tests/src/test/resources/ScalaToMeta/Aliases/Expected.scala
+++ b/tests/src/test/resources/ScalaToMeta/Aliases/Expected.scala
@@ -1,0 +1,4 @@
+object Aliases {
+  type Pair[T] = (T, T)
+  val x: Pair[Int] = ???
+}

--- a/tests/src/test/resources/ScalaToMeta/Aliases/Original.scala
+++ b/tests/src/test/resources/ScalaToMeta/Aliases/Original.scala
@@ -1,0 +1,4 @@
+object Aliases {
+  type Pair[T] = (T, T)
+  val x: Pair[Int] = ???
+}

--- a/tests/src/test/resources/ScalaToMeta/Applications/Expected.scala
+++ b/tests/src/test/resources/ScalaToMeta/Applications/Expected.scala
@@ -1,1 +1,4 @@
-object Applications { (??? : Int => Int)(42) }
+object Applications {
+  (??? : Int => Int)(42)
+  (1 :: Nil)(0)
+}

--- a/tests/src/test/resources/ScalaToMeta/Applications/Expected.scala
+++ b/tests/src/test/resources/ScalaToMeta/Applications/Expected.scala
@@ -1,0 +1,1 @@
+object Applications { (??? : Int => Int)(42) }

--- a/tests/src/test/resources/ScalaToMeta/Applications/Original.scala
+++ b/tests/src/test/resources/ScalaToMeta/Applications/Original.scala
@@ -1,3 +1,4 @@
 object Applications {
   (??? : Int => Int)(42)
+  (1 :: Nil)(0)
 }

--- a/tests/src/test/resources/ScalaToMeta/Applications/Original.scala
+++ b/tests/src/test/resources/ScalaToMeta/Applications/Original.scala
@@ -1,0 +1,3 @@
+object Applications {
+  (??? : Int => Int)(42)
+}

--- a/tests/src/test/resources/ScalaToMeta/NamesDefaults/Expected.scala
+++ b/tests/src/test/resources/ScalaToMeta/NamesDefaults/Expected.scala
@@ -132,3 +132,9 @@ object NamesDefaultsSuper {
   class Oneone6 extends Oneone(100)(100)
   class Oneone7 extends Oneone()()
 }
+object NamesDefaultsImplicit {
+  def foo(x: Int = 2, y: Int = 3)(implicit z: Int) = ???
+  implicit val t = 4
+  foo(y = 5)
+  foo(y = 5)(6)
+}

--- a/tests/src/test/resources/ScalaToMeta/NamesDefaults/Original.scala
+++ b/tests/src/test/resources/ScalaToMeta/NamesDefaults/Original.scala
@@ -132,3 +132,9 @@ object NamesDefaultsSuper {
   class Oneone6 extends Oneone(100)(100)
   class Oneone7 extends Oneone()()
 }
+object NamesDefaultsImplicit {
+  def foo(x: Int = 2, y: Int = 3)(implicit z: Int) = ???
+  implicit val t = 4
+  foo(y = 5)
+  foo(y = 5)(6)
+}

--- a/tests/src/test/resources/ScalaToMeta/ScalaToMeta/Expected.scala
+++ b/tests/src/test/resources/ScalaToMeta/ScalaToMeta/Expected.scala
@@ -59,7 +59,7 @@ class ScalaToMeta extends FunSuite {
       if (debug) println(unit.body)
       for (workItem <- unit.toCheck) workItem()
       throwIfErrors()
-      val h = Scalahost(compiler).asInstanceOf[PalladiumHost with OurHost[compiler.type] {}]
+      val h = Scalahost(compiler).asInstanceOf[PalladiumHost with OurHost[compiler.type]]
       val ptree = h.toPalladium(unit.body, classOf[Source])
       if (debug) println(ptree.show[Code])
       if (debug) println(ptree.show[Raw])

--- a/tests/src/test/resources/ScalaToMeta/Select/Expected.scala
+++ b/tests/src/test/resources/ScalaToMeta/Select/Expected.scala
@@ -1,0 +1,6 @@
+object Select {
+  val x1: Nil.type = Nil
+  val x2: scala.Nil.type = scala.Nil
+  val x3: scala.collection.immutable.Nil.type = scala.collection.immutable.Nil
+  val x4: scala.Traversable.type = scala.Traversable
+}

--- a/tests/src/test/resources/ScalaToMeta/Select/Original.scala
+++ b/tests/src/test/resources/ScalaToMeta/Select/Original.scala
@@ -1,0 +1,6 @@
+object Select {
+  val x1: Nil.type = Nil
+  val x2: scala.Nil.type = scala.Nil
+  val x3: scala.collection.immutable.Nil.type = scala.collection.immutable.Nil
+  val x4: scala.Traversable.type = scala.Traversable
+}

--- a/tests/src/test/resources/ScalaToMeta/Typers/Expected.scala
+++ b/tests/src/test/resources/ScalaToMeta/Typers/Expected.scala
@@ -160,7 +160,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
     def context1 = context
     def dropExistential(tp: Type): Type = tp match {
       case ExistentialType(tparams, tpe) =>
-        new SubstWildcardMap(tparams)(tp)
+        (new SubstWildcardMap(tparams))(tp)
       case TypeRef(_, sym, _) if sym.isAliasType =>
         val tp0 = tp.dealias
         if (tp eq tp0) {

--- a/tests/src/test/resources/ScalaToMeta/Types/Expected.scala
+++ b/tests/src/test/resources/ScalaToMeta/Types/Expected.scala
@@ -38,4 +38,9 @@ object Types {
     type T31 = Cons[Z[_ >: String], _ <: Int]
   }
   type T32 = List[Int] @scala.annotation.unchecked.uncheckedVariance
+  type @@[T, U] = T with U
+  type T33 = Int @@ Int
+  type T34 = Int @@ Int
+  object M { type ++[T, U] = T with U }
+  type T35 = M.++[Int, Int]
 }

--- a/tests/src/test/resources/ScalaToMeta/Types/Original.scala
+++ b/tests/src/test/resources/ScalaToMeta/Types/Original.scala
@@ -45,4 +45,13 @@ object Types {
   }
 
   type T32 = List[Int] @scala.annotation.unchecked.uncheckedVariance
+
+  type @@[T, U] = T with U
+  type T33 = @@[Int, Int]
+  type T34 = Int @@ Int
+
+  object M {
+    type ++[T, U] = T with U
+  }
+  type T35 = M.++[Int, Int]
 }


### PR DESCRIPTION
Now scala.reflect => scala.meta conversion doesn't crash on those, but I didn't have time to check that the result is sensible.