### PR TITLE
fixes scalaz compilation

### DIFF
--- a/foundation/src/main/scala/org/scalameta/reflection/Ensugar.scala
+++ b/foundation/src/main/scala/org/scalameta/reflection/Ensugar.scala
@@ -87,7 +87,7 @@ trait Ensugar {
             }
           } catch {
             case err: _root_.java.lang.AssertionError => logFailure(); throw err
-            case err: _root_.org.scalameta.UnreachableError.type => logFailure(); throw err
+            case err: _root_.org.scalameta.UnreachableError => logFailure(); throw err
             case ex: _root_.scala.Exception => logFailure(); throw ex
           }
         }
@@ -206,7 +206,7 @@ trait Ensugar {
                     case (tree @ Annotated(_, arg), annot :: rest) => treeCopy.Annotated(tree, annot, loop(arg, rest))
                     case (OriginalAnnottee(TypeTreeWithOriginal(tree)), Nil) => tree
                     case (OriginalAnnottee(tree), Nil) => tree
-                    case _ => unreachable
+                    case _ => unreachable(debug(tree, annots))
                   }
                   val annots = tree.tpe.require[AnnotatedType].annotations.map(_.original)
                   require(annots.forall(_.nonEmpty))
@@ -320,7 +320,7 @@ trait Ensugar {
               case original if original.nonEmpty && original.tpe != null => Some(original)
               case original if original.nonEmpty && original.tpe == null => Some(fixupAttributesOfClassfileAnnotOriginal(original))
               case EmptyTree if isSyntheticAnnotation(ann) => None
-              case EmptyTree => unreachable
+              case EmptyTree => unreachable(debug(ann))
             }
             def fixupAttributesOfClassfileAnnotOriginal(original: Tree): Tree = {
               // TODO: support classfile annotation args (non-literal ann.original.argss are untyped at the moment)

--- a/foundation/src/main/scala/org/scalameta/reflection/LogicalSymbols.scala
+++ b/foundation/src/main/scala/org/scalameta/reflection/LogicalSymbols.scala
@@ -14,9 +14,8 @@ trait LogicalSymbols {
 
   implicit class RichLogicalSymbol(gsym: g.Symbol) {
     def toLogical: l.Symbol = {
-      val gsym0 = gsym
-      val results = logicalSymbols(List(gsym0))
-      require(gsym0 != null && results != null && results.length == 1)
+      val results = logicalSymbols(List(gsym))
+      require(results.length == 1 && debug(gsym, results))
       results.head
     }
   }
@@ -332,7 +331,7 @@ trait LogicalSymbols {
           case (l.AbstractVar(g1, s1), l.AbstractVar(g2, s2)) => l.AbstractVar(g1.orElse(g2), s1.orElse(s2))
           case (l.Val(f1, g1), l.Val(f2, g2)) => l.Val(f1.orElse(f2), g1.orElse(g2))
           case (l.Var(f1, g1, s1), l.Var(f2, g2, s2)) => l.Var(f1.orElse(f2), g1.orElse(g2), s1.orElse(s2))
-          case _ => unreachable
+          case _ => unreachable(debug(lsym1, lsym2))
         }
         val partial = result(i)
         val found = completeResult.indexWhere(accum => accum.productPrefix == partial.productPrefix && accum.name == partial.name)

--- a/foundation/src/main/scala/org/scalameta/reflection/LogicalSymbols.scala
+++ b/foundation/src/main/scala/org/scalameta/reflection/LogicalSymbols.scala
@@ -258,6 +258,7 @@ trait LogicalSymbols {
           if (gsym == g.NoSymbol) {
             l.None
           } else if (gsym.isTerm && !gsym.isMethod && !gsym.isModule) {
+            require(!gsym.owner.isRefinementClass)
             if (gsym.hasFlag(PARAM)) l.TermParameter(gsym)
             else {
               if (gsym.hasFlag(MUTABLE)) l.Var(gsym, gsym.getter, gsym.setter)
@@ -270,14 +271,14 @@ trait LogicalSymbols {
             require(gsym.hasFlag(METHOD))
             if (gsym.hasFlag(ACCESSOR)) {
               if (gsym.hasFlag(STABLE)) {
-                if (gsym.hasFlag(DEFERRED)) l.AbstractVal(gsym)
+                if (gsym.hasFlag(DEFERRED) || gsym.owner.isRefinementClass) l.AbstractVal(gsym)
                 else l.Val(gsym.accessed, gsym)
               } else {
                 if (!gsym.name.endsWith(g.nme.SETTER_SUFFIX)) {
-                  if (gsym.hasFlag(DEFERRED)) l.AbstractVar(gsym, gsym.setter)
+                  if (gsym.hasFlag(DEFERRED) || gsym.owner.isRefinementClass) l.AbstractVar(gsym, gsym.setter)
                   else l.Var(gsym.accessed, gsym, gsym.setter)
                 } else {
-                  if (gsym.hasFlag(DEFERRED)) l.AbstractVar(gsym.getter, gsym)
+                  if (gsym.hasFlag(DEFERRED) || gsym.owner.isRefinementClass) l.AbstractVar(gsym.getter, gsym)
                   else l.Var(gsym.accessed, gsym.getter, gsym)
                 }
               }
@@ -285,7 +286,7 @@ trait LogicalSymbols {
               if (gsym.hasFlag(MACRO)) l.Macro(gsym)
               else if (gsym.isPrimaryConstructor) l.PrimaryCtor(gsym)
               else if (gsym.isConstructor) l.SecondaryCtor(gsym)
-              else if (gsym.hasFlag(DEFERRED)) l.AbstractDef(gsym)
+              else if (gsym.hasFlag(DEFERRED) || gsym.owner.isRefinementClass) l.AbstractDef(gsym)
               else l.Def(gsym)
             }
           } else if (gsym.isModule) {

--- a/foundation/src/main/scala/org/scalameta/reflection/LogicalSymbols.scala
+++ b/foundation/src/main/scala/org/scalameta/reflection/LogicalSymbols.scala
@@ -235,7 +235,7 @@ trait LogicalSymbols {
       val allowedPrefixes = List("$repl_$init", "$line", "$read", "$eval")
       !gsym.owner.isPackageClass || allowedPrefixes.exists(prefix => gsym.name.decoded.startsWith(prefix))
     }
-    if (!gsym.exists) return false
+    if (gsym != g.NoSymbol && !gsym.exists) return false
     if (gsym.name.decoded.contains("$") && !allowSynthetic(gsym)) return false
     if (gsym.name.toString.contains(g.nme.DEFAULT_GETTER_STRING)) return false
     if (gsym.isPrimaryConstructor && gsym.name == g.nme.MIXIN_CONSTRUCTOR) return false

--- a/foundation/src/main/scala/org/scalameta/reflection/SymbolHelpers.scala
+++ b/foundation/src/main/scala/org/scalameta/reflection/SymbolHelpers.scala
@@ -66,7 +66,7 @@ trait SymbolHelpers {
           if (targs.nonEmpty) implRef = TypeApply(implRef, targs).setType(appliedType(methodSym.info, targs.map(_.tpe)))
           MacroBody.Reflect(implRef)
         case _ :: _ =>
-          unreachable
+          unreachable(debug(macroSigs(sym)))
         case _ =>
           MacroBody.None
       }

--- a/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/Attributes.scala
+++ b/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/Attributes.scala
@@ -58,8 +58,7 @@ trait Attributes extends GlobalToolkit with MetaToolkit {
       ptree.withDenot(gpre, gsym.toLogical)
     }
     def withDenot(gpre: g.Type, lsym: l.Symbol)(implicit ev: CanHaveDenot[T]): T = {
-      val ptree0 = ptree // NOTE: this is here only to provide an unqualified Ident for the `require` macro
-      require(ptree0.isInstanceOf[m.Name] && gpre != null && ((lsym == l.None) ==> ptree.isInstanceOf[m.Term.Super]))
+      require(((lsym == l.None) ==> ptree.isInstanceOf[m.Term.Super]) && debug(ptree, gpre, lsym))
       val scratchpad = ptree.scratchpad :+ ScratchpadDatum.Denotation(gpre, lsym)
       val ptree1 = ptree match {
         case ptree: m.Name.Anonymous => ptree.copy(denot = denot(gpre, lsym), sigma = h.Sigma.Naive)
@@ -73,7 +72,7 @@ trait Attributes extends GlobalToolkit with MetaToolkit {
         case ptree: m.Ctor.Name => ptree.copy(denot = denot(gpre, lsym), sigma = h.Sigma.Naive)
         case ptree: m.Term.This => ptree.copy(denot = denot(gpre, lsym), sigma = h.Sigma.Naive)
         case ptree: m.Term.Super => ptree.copy(denot = denot(gpre, lsym), sigma = h.Sigma.Naive)
-        case _ => unreachable
+        case _ => unreachable(debug(ptree, ptree.show[Raw]))
       }
       ptree1.withScratchpad(scratchpad).require[T]
     }

--- a/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/SymbolTables.scala
+++ b/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/SymbolTables.scala
@@ -37,7 +37,7 @@ trait SymbolTables extends GlobalToolkit with MetaToolkit {
         if (gsym.isMethod && !gsym.asMethod.isGetter) h.Signature.Method(gsym.jvmsig)
         else if (gsym.isTerm || (gsym.hasFlag(DEFERRED | EXISTENTIAL) && gsym.name.endsWith(g.nme.SINGLETON_SUFFIX))) h.Signature.Term
         else if (gsym.isType) h.Signature.Type
-        else unreachable
+        else unreachable(debug(gsym, gsym.flags, gsym.getClass, gsym.owner))
       }
       if (sys.props("convert.debug") != null) println(lsym)
       val gsym = lsym.gsymbol

--- a/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/ToGtype.scala
+++ b/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/ToGtype.scala
@@ -198,7 +198,7 @@ trait ToGtype extends GlobalToolkit with MetaToolkit {
               case _: m.Decl.Def => gowner(mrefine).mkLabstractDef(mname.toString)
               case _: m.Decl.Type => gowner(mrefine).mkLabstractType(mname.toString)
               case _: m.Defn.Type => gowner(mrefine).mkLtype(mname.toString)
-              case _ => unreachable
+              case _ => unreachable(debug(mrefine, mrefine.show[Raw]))
             })
             lrefine.gsymbols.foreach(gscope.enter)
             mrefine -> lrefine
@@ -211,7 +211,7 @@ trait ToGtype extends GlobalToolkit with MetaToolkit {
             val lquant = symbolTable.lookupOrElseUpdate(mname.denot.symbol, mquant match {
               case _: m.Decl.Val => gowner(mquant).mkLexistentialVal(mname.toString)
               case _: m.Decl.Type => gowner(mquant).mkLexistentialType(mname.toString)
-              case _ => unreachable
+              case _ => unreachable(debug(mquant, mquant.show[Raw]))
             })
             mquant -> lquant
           })

--- a/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/ToM.scala
+++ b/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/ToM.scala
@@ -24,7 +24,7 @@ trait ToM extends GlobalToolkit with MetaToolkit {
     private def dumbcvt(in: g.Tree): m.Name = {
       if (gsym.isTerm) m.Term.Name(in.alias)
       else if (gsym.isType) m.Type.Name(in.alias)
-      else unreachable
+      else unreachable(debug(gsym, gsym.flags, gsym.getClass, gsym.owner))
     }
     def precvt(pre: g.Type, in: g.Tree): mTermOrTypeName = dumbcvt(in).withDenot(pre, gsym).require[mTermOrTypeName]
     def rawcvt(in: g.Tree): mTermOrTypeName = dumbcvt(in).withDenot(gsym).require[mTermOrTypeName]
@@ -59,8 +59,8 @@ trait ToM extends GlobalToolkit with MetaToolkit {
       case v: Double => m.Lit.Double(v)
       case v: String => m.Lit.String(v)
       case v: Char => m.Lit.Char(v)
-      case v: g.Type => unreachable
-      case v: g.Symbol => unreachable
+      case v: g.Type => unreachable(debug(gconst))
+      case v: g.Symbol => unreachable(debug(gconst))
     }
   }
 }

--- a/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/ToMannot.scala
+++ b/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/ToMannot.scala
@@ -36,7 +36,7 @@ trait ToMannot extends GlobalToolkit with MetaToolkit {
               case g.NestedAnnotArg(gannot: g.AnnotationInfo) =>
                 mannotcore(gannot)
               case _ =>
-                unreachable
+                unreachable(debug(garg))
             }
             gassocs.map({ case (gname, garg) =>
               val gparam = gctor.paramss.flatten.find(_.name == gname).get.asTerm

--- a/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/ToMtree.scala
+++ b/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/ToMtree.scala
@@ -73,7 +73,7 @@ trait ToMtree extends GlobalToolkit with MetaToolkit {
           } else if (gmods.hasFlag(LOCAL)) {
             if (gmods.hasFlag(PROTECTED)) List(m.Mod.Protected(m.Term.This(None).withDenot(gpriv)))
             else if (gmods.hasFlag(PRIVATE)) List(m.Mod.Private(m.Term.This(None).withDenot(gpriv)))
-            else unreachable
+            else unreachable(debug(gmods))
           } else if (gmods.hasAccessBoundary && gpriv != g.NoSymbol) {
             // TODO: `private[pkg] class C` doesn't have PRIVATE in its flags
             // so we need to account for that!
@@ -119,7 +119,7 @@ trait ToMtree extends GlobalToolkit with MetaToolkit {
       }
       def mtypebounds(gtpt: g.Tree): m.Type.Bounds = gtpt match {
         case g.TypeBoundsTree(glo, ghi) => m.Type.Bounds(if (glo.isEmpty) None else Some[m.Type](glo.cvt_!), if (ghi.isEmpty) None else Some[m.Type](ghi.cvt_!))
-        case _ => unreachable
+        case _ => unreachable(debug(gtpt, g.showRaw(gtpt)))
       }
       def marg(garg: g.Tree): m.Term.Arg = garg match {
         case g.Typed(expr, g.Ident(g.tpnme.WILDCARD_STAR)) => m.Term.Arg.Repeated(expr.cvt_!)
@@ -374,7 +374,7 @@ trait ToMtree extends GlobalToolkit with MetaToolkit {
         rhs match {
           case q"if ($cond) { $body; $cont } else ()" if name.startsWith(g.nme.WHILE_PREFIX) => m.Term.While(cond.cvt_!, body.cvt_!)
           case q"$body; if ($cond) $cont else ()" if name.startsWith(g.nme.DO_WHILE_PREFIX) => m.Term.Do(body.cvt_!, cond.cvt_!)
-          case _ => unreachable
+          case _ => unreachable(debug(rhs, g.showRaw(rhs)))
         }
       case in @ g.Import(expr, selectors) =>
         // TODO: collapse desugared chains of imports

--- a/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/ToMtree.scala
+++ b/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/ToMtree.scala
@@ -623,14 +623,13 @@ trait ToMtree extends GlobalToolkit with MetaToolkit {
       case in @ g.SingletonTypeTree(ref) =>
         m.Type.Singleton(ref.cvt_!)
       case in @ g.CompoundTypeTree(templ) if pt <:< typeOf[m.Type] =>
-        val template @ m.Template(early, parents, _, stats) = templ.cvt : m.Template
-        require(template.isCompoundTypeCompatible)
-        m.Type.Compound(parents.map(_.tpe.require[m.Type]), stats.getOrElse(Nil))
+        val SyntacticTemplate(gsupersym, gparents, gself, gearlydefns, gstats) = templ
+        require(gsupersym == g.NoSymbol && gself == g.noSelfType && gearlydefns.isEmpty)
+        m.Type.Compound(gparents.cvt_!, gstats.cvt_!)
       case in @ g.CompoundTypeTree(templ) if pt <:< typeOf[m.Pat.Type] =>
-        // TODO: this doesn't handle situations like `List(42) match { case _: (List[t] { def head: Int }) => }`
-        val template @ m.Template(early, parents, _, stats) = templ.cvt : m.Template
-        require(template.isCompoundTypeCompatible)
-        m.Pat.Type.Compound(parents.map(_.tpe.pat.require[m.Pat.Type]), stats.getOrElse(Nil))
+        val SyntacticTemplate(gsupersym, gparents, gself, gearlydefns, gstats) = templ
+        require(gsupersym == g.NoSymbol && gself == g.noSelfType && gearlydefns.isEmpty)
+        m.Pat.Type.Compound(gparents.cvt_!, gstats.cvt_!)
       case in @ g.AppliedTypeTree(tpt, args) if pt <:< typeOf[m.Type.Arg] =>
         // TODO: infer whether that was really Apply, Function or Tuple
         // TODO: precisely infer whether that was infix application or normal application

--- a/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/ToMtype.scala
+++ b/interface/src/main/scala/scala/meta/internal/hosts/scalac/converters/ToMtype.scala
@@ -99,13 +99,18 @@ trait ToMtype extends GlobalToolkit with MetaToolkit {
                 }
               }
             }).withOriginal(gtpe)
-            val margs = args.map(_.toMtype)
             if (args.isEmpty) mref
             else {
-              if (g.definitions.FunctionClass.seq.contains(sym)) m.Type.Function(margs.init, margs.last)
-              else if (g.definitions.TupleClass.seq.contains(sym) && margs.length > 1) m.Type.Tuple(margs)
-              else if (sym.name.looksLikeInfix && mref.isInstanceOf[m.Type.Name] && margs.length == 2) m.Type.ApplyInfix(margs(0), mref.require[m.Type.Name], margs(1))
-              else m.Type.Apply(mref, margs)
+              if (g.definitions.FunctionClass.seq.contains(sym) && args.nonEmpty) {
+                val funargs :+ funret = args
+                m.Type.Function(funargs.map(_.toMtypeArg), funret.toMtype)
+              } else if (g.definitions.TupleClass.seq.contains(sym) && args.length > 1) {
+                m.Type.Tuple(args.map(_.toMtype))
+              } else if (sym.name.looksLikeInfix && mref.isInstanceOf[m.Type.Name] && args.length == 2) {
+                m.Type.ApplyInfix(args(0).toMtype, mref.require[m.Type.Name], args(1).toMtype)
+              } else {
+                m.Type.Apply(mref, args.map(_.toMtype))
+              }
             }
           }
         case g.RefinedType(parents, decls) =>

--- a/plugin/src/main/scala/scala/meta/internal/hosts/scalac/macros/Expansion.scala
+++ b/plugin/src/main/scala/scala/meta/internal/hosts/scalac/macros/Expansion.scala
@@ -81,7 +81,7 @@ trait Expansion extends scala.reflect.internal.show.Printers {
             }
             lazy val scalametaResult: Any = scalametaInvocation match {
               case term: ScalametaTerm => scalametaEval(term)
-              case _ => unreachable
+              case other => unreachable(debug(other, other.show[Raw]))
             }
             lazy val scalareflectResult: Any = scalametaResult match {
               case scalametaTree: ScalametaTree =>

--- a/tests/src/test/resources/ScalaToMeta/ByName/Expected.scala
+++ b/tests/src/test/resources/ScalaToMeta/ByName/Expected.scala
@@ -1,0 +1,5 @@
+sealed abstract class ByName[A] {
+  def foldRight[B](z: => B)(f: (=> A) => (=> B) => B): B = ???
+  def cons[A](a: => A, as: => ByName[A]): ByName[A] = ???
+  def ++(e: => ByName[A]): ByName[A] = foldRight[ByName[A]](e)(cons[A](_, _).curried)
+}

--- a/tests/src/test/resources/ScalaToMeta/ByName/Original.scala
+++ b/tests/src/test/resources/ScalaToMeta/ByName/Original.scala
@@ -1,0 +1,6 @@
+// NOTE: parts of this code are taken from EphemeralStream.scala from scalaz
+sealed abstract class ByName[A] {
+  def foldRight[B](z: => B)(f: (=> A) => (=> B) => B): B = ???
+  def cons[A](a: => A, as: => ByName[A]): ByName[A] = ???
+  def ++(e: => ByName[A]): ByName[A] = foldRight[ByName[A]](e)((cons[A](_, _)).curried)
+}

--- a/tests/src/test/resources/ScalaToMeta/Constructors/Expected.scala
+++ b/tests/src/test/resources/ScalaToMeta/Constructors/Expected.scala
@@ -13,4 +13,6 @@ object Constructors {
     }
   }
   class C6[T: scala.reflect.ClassTag](x: Int) { def this() = this(0) }
+  class C7[T, U]
+  new C7[Int, Int]
 }

--- a/tests/src/test/resources/ScalaToMeta/Constructors/Original.scala
+++ b/tests/src/test/resources/ScalaToMeta/Constructors/Original.scala
@@ -7,4 +7,6 @@ object Constructors {
   class C4(x: Int) { def this() = this(0) }
   class C5(x: Int) { def this() { this(0); println("hello world") } }
   class C6[T: scala.reflect.ClassTag](x: Int) { def this() = this(0) }
+  class C7[T, U]
+  new (Int C7 Int)
 }

--- a/tests/src/test/resources/ScalaToMeta/Refined/Expected.scala
+++ b/tests/src/test/resources/ScalaToMeta/Refined/Expected.scala
@@ -1,0 +1,10 @@
+trait Refined { def test = ((x: Int, y: Int) => Refined.create).curried }
+object Refined {
+  def create = new Refined {
+    val x = ???
+    var y = ???
+    def z(w: Int) = ???
+    type T1 <: Nothing
+    type T2 = Nothing
+  }
+}

--- a/tests/src/test/resources/ScalaToMeta/Refined/Original.scala
+++ b/tests/src/test/resources/ScalaToMeta/Refined/Original.scala
@@ -1,0 +1,13 @@
+trait Refined {
+  def test = ((x: Int, y: Int) => Refined.create).curried
+}
+
+object Refined {
+  def create = new Refined {
+    val x = ???
+    var y = ???
+    def z(w: Int) = ???
+    type T1 <: Nothing
+    type T2 = Nothing
+  }
+}

--- a/tests/src/test/resources/ScalaToMeta/Super/Expected.scala
+++ b/tests/src/test/resources/ScalaToMeta/Super/Expected.scala
@@ -1,4 +1,7 @@
 object Super {
   class C { def ++=(x: Int) = () }
   class D extends C { override def ++=(x: Int) = super.++=(x) }
+  class T1 { def foo: Int = ??? }
+  trait T2
+  new T1 with T2 { override def foo: Int = super.foo }
 }

--- a/tests/src/test/resources/ScalaToMeta/Super/Original.scala
+++ b/tests/src/test/resources/ScalaToMeta/Super/Original.scala
@@ -1,4 +1,10 @@
 object Super {
   class C { def ++=(x: Int) = () }
   class D extends C { override def ++=(x: Int) = super.++=(x) }
+
+  class T1 { def foo: Int = ??? }
+  trait T2
+  new T1 with T2 {
+    override def foo: Int = super.foo
+  }
 }

--- a/tests/src/test/resources/ScalaToMeta/Types/Expected.scala
+++ b/tests/src/test/resources/ScalaToMeta/Types/Expected.scala
@@ -19,6 +19,7 @@ object Types {
   type T10 = (X, X)
   type T11 = X { def x: Int }
   type T12 = B with Y { def x: Int }
+  type T12x = x5.type { type T = Int }
   new X {} match {
     case x13: X =>
   }

--- a/tests/src/test/resources/ScalaToMeta/Types/Original.scala
+++ b/tests/src/test/resources/ScalaToMeta/Types/Original.scala
@@ -24,6 +24,7 @@ object Types {
   type T10 = (X, X)
   type T11 = X { def x: Int }
   type T12 = B with Y { def x: Int }
+  type T12x = x5.type { type T = Int }
 
   new X{} match { case x13: X => }
 


### PR DESCRIPTION
Btw here are the new performance numbers:
* `sbt compile` in scalaz with scalahost disabled: 105s
* `sbt compile` in scalaz with scalahost enabled: 154s

I'd say that the slowdown is within the realm of tolerable for pre-alpha software, which at the moment we still are. I'm especially satisfied with the fact that this slowdown takes into account not only the syntactic conversion from scala.reflect to scala.meta for the entire project, but also population of all names' denotations (i.e. semantic conversion of symbols, their prefixes, denotations of their prefixes, etc).